### PR TITLE
Update and pin Node and Mongo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 
 RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y curl build-essential redis-server mongodb-server netcat
+RUN apt-get install -y curl build-essential redis-server mongodb-server netcat python
 
 # gpg keys listed at https://github.com/nodejs/node#release-team
 RUN set -ex \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 
 RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y curl build-essential redis-server mongodb-server
+RUN apt-get install -y curl build-essential redis-server mongodb-server netcat
 
 # gpg keys listed at https://github.com/nodejs/node#release-team
 RUN set -ex \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,45 @@
 FROM ubuntu:16.04
 
 RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y build-essential redis-server mongodb-server nodejs npm
-RUN ln -s /usr/bin/nodejs /usr/bin/node
+RUN apt-get install -y curl build-essential redis-server mongodb-server
+
+# gpg keys listed at https://github.com/nodejs/node#release-team
+RUN set -ex \
+  && for key in \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+    56730D5401028683275BD23C23EFEFE93C4CFFFE \
+    77984A986EBC2AA786BC0F66B01FBB92821C587A \
+  ; do \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --keyserver keyserver.pgp.com --recv-keys "$key" || \
+    gpg --keyserver pgp.mit.edu --recv-keys "$key" ; \
+  done
+
+ENV NODE_VERSION 8.9.1
+
+RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+  && case "${dpkgArch##*-}" in \
+    amd64) ARCH='x64';; \
+    ppc64el) ARCH='ppc64le';; \
+    s390x) ARCH='s390x';; \
+    arm64) ARCH='arm64';; \
+    armhf) ARCH='armv7l';; \
+    i386) ARCH='x86';; \
+    *) echo "unsupported architecture"; exit 1 ;; \
+  esac \
+  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
+  && curl -SLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+  && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+  && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+&& ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
 RUN npm install -g grunt-cli
 
 RUN mkdir /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
 FROM ubuntu:16.04
 
-RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y curl build-essential redis-server mongodb-server netcat python
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F3730359A14518585931BC711F9BA15703C6 && \
+  echo "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-3.4.list
+
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install -y curl build-essential redis-server mongodb-org-server=3.4.10 netcat python
+
+RUN mkdir -p /data/db /data/configdb
 
 # gpg keys listed at https://github.com/nodejs/node#release-team
 RUN set -ex \
@@ -20,7 +25,7 @@ RUN set -ex \
     gpg --keyserver pgp.mit.edu --recv-keys "$key" ; \
   done
 
-ENV NODE_VERSION 8.9.1
+ENV NODE_VERSION 6.9.5
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 /usr/bin/redis-server /etc/redis/redis.conf
-service mongodb start
+(mongod & ) 1>/dev/null
 
 count=1
 max_wait=30
@@ -17,7 +17,7 @@ do
   fi
 
   sleep 1
-  echo "."
+  echo -n "."
   count=$((count+1))
 done
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -3,7 +3,23 @@
 /usr/bin/redis-server /etc/redis/redis.conf
 service mongodb start
 
-sleep 30
+count=1
+max_wait=30
 
-cd /app
-exec $1
+while [ $count -le $max_wait ]
+do
+  if nc -z localhost 27017
+  then
+    echo "   Connected to mongo"
+    cd /app
+    exec "$@"
+    exit 0
+  fi
+
+  sleep 1
+  echo "."
+  count=$((count+1))
+done
+
+echo "   Failed to connect to mongo within $max_wait seconds"
+exit 1


### PR DESCRIPTION
#### Review

This PR does a few different things:

1. Upgrade Node and pin to 6.9
1. Upgrade Mongo and pin to 3.4
1. Replace a sleep with a polling loop to reduce the time spent waiting unnecessarily for mongo
   This was mostly necessary whilst working on this container
1. Add python so the `v8-profiler` module can be built within the docker container
   If your host OS needs different bindings for dependencies then python is required in order to actually build the bindings

#### Who needs to know

@jpallen @ShaneKilkelly 